### PR TITLE
Add elevation of 4dp to toolbar

### DIFF
--- a/MaterialNavigationDrawerModule/src/main/res/layout/activity_google_navigation_drawer.xml
+++ b/MaterialNavigationDrawerModule/src/main/res/layout/activity_google_navigation_drawer.xml
@@ -11,6 +11,7 @@
 
     <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
+        android:elevation="4dp"
         android:layout_height="?attr/actionBarSize"
         android:layout_width="match_parent"
         android:background="?attr/colorPrimary"

--- a/MaterialNavigationDrawerModule/src/main/res/layout/activity_material_navigation_drawer.xml
+++ b/MaterialNavigationDrawerModule/src/main/res/layout/activity_material_navigation_drawer.xml
@@ -19,6 +19,7 @@
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
+            android:elevation="4dp"
             android:layout_height="?attr/actionBarSize"
             android:layout_width="match_parent"
             android:background="?attr/colorPrimary"

--- a/MaterialNavigationDrawerModule/src/main/res/layout/activity_material_navigation_drawer_customheader.xml
+++ b/MaterialNavigationDrawerModule/src/main/res/layout/activity_material_navigation_drawer_customheader.xml
@@ -19,6 +19,7 @@
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
+            android:elevation="4dp"
             android:layout_height="?attr/actionBarSize"
             android:layout_width="match_parent"
             android:background="?attr/colorPrimary"


### PR DESCRIPTION
An elevation of 4dp should be used to elevate the Toolbar on Android 5.
