### PR TITLE
fix to enable manual call of setSection. 

### DIFF
--- a/MaterialNavigationDrawerModule/src/main/java/it/neokree/materialnavigationdrawer/MaterialNavigationDrawer.java
+++ b/MaterialNavigationDrawerModule/src/main/java/it/neokree/materialnavigationdrawer/MaterialNavigationDrawer.java
@@ -981,8 +981,6 @@ public abstract class MaterialNavigationDrawer<Fragment> extends ActionBarActivi
      */
     public void setSection(MaterialSection section) {
         section.select();
-        syncSectionsState(section);
-
         switch (section.getTarget()) {
             case MaterialSection.TARGET_FRAGMENT:
                 // se l'utente clicca sulla stessa schermata in cui si trova si chiude il drawer e basta


### PR DESCRIPTION
it used to set target section as current and do nothing because it's already the current one. there's already a syncSectionsState call at the bottom of function.
